### PR TITLE
Fix infinite complete job clock

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -56,7 +56,7 @@ export function App() {
       const result = updateJob(jobs, jobIndex, {
         status: lastJsonMessage.Job.ExitCode === 0 ? 'Completed' : 'Error',
         markdownReport: lastJsonMessage.Job.MarkdownReport,
-        completedAt: new Date().toString()
+        completedAt: jobs[jobIndex].completedAt ? jobs[jobIndex].completedAt : new Date().toString()
       });
       
       if (!result.updatedJob) return;

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -56,7 +56,7 @@ export function App() {
       const result = updateJob(jobs, jobIndex, {
         status: lastJsonMessage.Job.ExitCode === 0 ? 'Completed' : 'Error',
         markdownReport: lastJsonMessage.Job.MarkdownReport,
-        completedAt: jobs[jobIndex].completedAt ? jobs[jobIndex].completedAt : new Date().toString()
+        completedAt: jobs[jobIndex]?.completedAt ? jobs[jobIndex].completedAt : new Date().toString()
       });
       
       if (!result.updatedJob) return;


### PR DESCRIPTION
Fixes the infinite clock due to re-render in useEffect:

![Infinite-clock-bug](https://github.com/user-attachments/assets/464a0990-6b1c-48ff-90ee-716aab626974)

![js-error-sharpdev](https://github.com/user-attachments/assets/83c5c07c-ae52-43ae-ba00-b2d3c451cfcf)
